### PR TITLE
checking for $response Content-Type does not work

### DIFF
--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -97,7 +97,7 @@ class Debugbar implements ServerMiddlewareInterface
         }
 
         //Html response
-        if (stripos($response->getHeaderLine('Content-Type'), 'text/html') === 0) {
+        if (stripos($request->getHeaderLine('Accept'), 'text/html') === 0) {
             $html = (string) $response->getBody();
 
             if (!$isAjax) {


### PR DESCRIPTION
Hi,

I tried it your way but it didn't work, I checked what **$request->getHeaderLine('Content-Type')** returns there and it always returns an empty string, so what I did is change it to **$request->getHeaderLine('Accept')** and that made it work.

Saludos Oscar! :smiley:
