### PR TITLE
Embed JS and CSS files online

### DIFF
--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -102,7 +102,15 @@ class Debugbar implements MiddlewareInterface
             $html = (string) $response->getBody();
 
             if (!$isAjax) {
-                $html = self::injectHtml($html, $renderer->renderHead(), '</head>');
+                ob_start();
+                echo "<style>\n";
+                $renderer->dumpCssAssets();
+                echo "\n</style>";
+                echo "<script>\n";
+                $renderer->dumpJsAssets();
+                echo "\n</script>";
+                $assetCode = ob_get_flush();
+                $html = self::injectHtml($html, $assetCode, '</head>');
             }
 
             $html = self::injectHtml($html, $renderer->render(!$isAjax), '</body>');


### PR DESCRIPTION
In my setup the webserver allows public access only to the folder where the front controller is located in (/var/www/html/public). When trying to use the debugbar it tries to embed JS and CSS files:
```html
<link rel="stylesheet" type="text/css" href="/vendor/maximebf/debugbar/src/DebugBar/Resources/openhandler.css">
<script type="text/javascript" src="/vendor/maximebf/debugbar/src/DebugBar/Resources/vendor/jquery/dist/jquery.min.js"></script>
```
The problem is that the vendor folder is not publicly accessible (for security reasons) and thus those CSS and JS files cannot be loaded. That is why I would appreciate a setting to embed JS and CSS code inline.
This is possible by using [$renderer->dumpJSAssets() and $renderer->dumpCSSAssets()](http://phpdebugbar.com/docs/rendering.html#rendering).