### PR TITLE
Addition of fileURI option to solve 404 issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,15 @@ Set true to dump the js/css code inline in the html. This fixes (or mitigate) so
 ```php
 $debugbar = (new Middlewares\Debugbar())->inline();
 ```
+### renderOptions
 
+Use this option to pass  render options to the debugbar as an array. A list of available options can be found at https://github.com/maximebf/php-debugbar/blob/master/src/DebugBar/JavascriptRenderer.php#L132
+
+An example usage would be to pass a new location for the ``base_url`` so that you can rewrite the location of the files needed to render the debug bar. This can be used with symlinks, .htaccess or routes to the files to ensure the debugbar files are accessible.
+
+```php
+$debugbar = (new Middlewares\Debugbar())->renderOptions(array('base_url' => "/MyProjectsSubDirectory/maximebf/debugbar/"));
+```
 ---
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about recent changes and [CONTRIBUTING](CONTRIBUTING.md) for contributing details.

--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -36,9 +36,9 @@ class Debugbar implements MiddlewareInterface
     private $inline = false;
 
     /**
-     * @var string A rewrite of the root path for the loaded files
+     * @var array A rewrite of the root path for the loaded files
      */
-    private $fileURI = null;
+    private $renderOptions = null;
 
     /**
      * @var ResponseFactoryInterface
@@ -66,9 +66,9 @@ class Debugbar implements MiddlewareInterface
     /**
      * Set the roo path variable
      */
-    public function fileURI(string $fileURI = null): self
+    public function renderOptions(array $renderOptions = null): self
     {
-        $this->fileURI = $fileURI;
+        $this->renderOptions = $renderOptions;
 
         return $this;
     }
@@ -100,8 +100,8 @@ class Debugbar implements MiddlewareInterface
     {
 
         $renderer = $this->debugbar->getJavascriptRenderer();
-        if( $this->fileURI ) {
-            $renderer->setOptions( array( 'base_url' => $this->fileURI ) );
+        if( $this->renderOptions ) {
+            $renderer->setOptions( $this->renderOptions );
         }
 
         //Asset response

--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -100,8 +100,8 @@ class Debugbar implements MiddlewareInterface
     {
 
         $renderer = $this->debugbar->getJavascriptRenderer();
-        if( $this->renderOptions ) {
-            $renderer->setOptions( $this->renderOptions );
+        if ($this->renderOptions) {
+            $renderer->setOptions($this->renderOptions);
         }
 
         //Asset response

--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -5,7 +5,6 @@ namespace Middlewares;
 
 use DebugBar\DebugBar as Bar;
 use DebugBar\StandardDebugBar;
-use DebugBar\JavascriptRenderer;
 use Middlewares\Utils\Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -5,6 +5,7 @@ namespace Middlewares;
 
 use DebugBar\DebugBar as Bar;
 use DebugBar\StandardDebugBar;
+use DebugBar\JavascriptRenderer;
 use Middlewares\Utils\Factory;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -36,6 +37,11 @@ class Debugbar implements MiddlewareInterface
     private $inline = false;
 
     /**
+     * @var string A rewrite of the root path for the loaded files
+     */
+    private $fileURI = null;
+
+    /**
      * @var ResponseFactoryInterface
      */
     private $responseFactory;
@@ -56,6 +62,16 @@ class Debugbar implements MiddlewareInterface
         $this->debugbar = $debugbar ?: new StandardDebugBar();
         $this->responseFactory = $responseFactory ?: Factory::getResponseFactory();
         $this->streamFactory = $streamFactory ?: Factory::getStreamFactory();
+    }
+
+    /**
+     * Set the roo path variable
+     */
+    public function fileURI(string $fileURI = null): self
+    {
+        $this->fileURI = $fileURI;
+
+        return $this;
     }
 
     /**
@@ -83,7 +99,11 @@ class Debugbar implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
+
         $renderer = $this->debugbar->getJavascriptRenderer();
+        if( $this->fileURI ) {
+            $renderer->setOptions( array( 'base_url' => $this->fileURI ) );
+        }
 
         //Asset response
         $path = $request->getUri()->getPath();

--- a/tests/DebugbarTest.php
+++ b/tests/DebugbarTest.php
@@ -117,4 +117,22 @@ class DebugbarTest extends TestCase
 
         $this->assertEquals(302, $response->getStatusCode());
     }
+
+    public function testRenderOptions()
+    {
+        $response = Dispatcher::run(
+            [
+                (new Debugbar())
+                    ->renderOptions(['base_url' => '/custom-url/']),
+                function () {
+                    return Factory::createResponse()
+                        ->withHeader('Content-Type', 'text/html');
+                },
+            ]
+        );
+
+        $body = (string) $response->getBody();
+
+        $this->assertNotFalse(strpos($body, '/custom-url/'));
+    }
 }


### PR DESCRIPTION
This change allows the URI of the files that Debug Bar needs to be re-written. When used with symlinks, .htaccess, creating routes to pass through the files, or other methods this can be used to solve the 404 problem when files aren't where Debug Bar expects them to be. This also provides a way to solve problems that arise from using Debug Bar with the base-path middleware.

As an example my project lives in a subfolder of my domain AND I have my vendor directory above my public folder. By rewriting the URI path for the Debug Bar files with ``(new Middlewares\Debugbar())->fileURI("/MyProjectsSubDirectory/maximebf/debugbar/")`` I am then able to create corresponding routes that link back to the files in the "../src/vendor/maximebf/debugbar/src/DebugBar/Resources/" location that isn't publicly accessible.