### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "squizlabs/php_codesniffer": "^3.0",
         "oscarotero/php-cs-fixer-config": "^1.0",
         "phpstan/phpstan": "^0.12",
-        "laminas/laminas-diactoros": "^2.3"
+        "laminas/laminas-diactoros": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Debugbar.php
+++ b/src/Debugbar.php
@@ -54,9 +54,9 @@ class Debugbar implements MiddlewareInterface
      * Set the debug bar.
      */
     public function __construct(
-        Bar $debugbar = null,
-        ResponseFactoryInterface $responseFactory = null,
-        StreamFactoryInterface $streamFactory = null
+        ?Bar $debugbar = null,
+        ?ResponseFactoryInterface $responseFactory = null,
+        ?StreamFactoryInterface $streamFactory = null
     ) {
         $this->debugbar = $debugbar ?: new StandardDebugBar();
         $this->responseFactory = $responseFactory ?: Factory::getResponseFactory();
@@ -66,7 +66,7 @@ class Debugbar implements MiddlewareInterface
     /**
      * Set the roo path variable
      */
-    public function renderOptions(array $renderOptions = null): self
+    public function renderOptions(?array $renderOptions = null): self
     {
         $this->renderOptions = $renderOptions;
 


### PR DESCRIPTION
I recently updated my php version to 8.4, and have been encountering a lot of deprecation warnings, this PR aims to silence them by adding nullable types where the default value is null in the method definition